### PR TITLE
Refactoring & Modify: Withdraw User logic

### DIFF
--- a/src/main/java/com/example/weup/entity/Member.java
+++ b/src/main/java/com/example/weup/entity/Member.java
@@ -22,7 +22,7 @@ public class Member {
     private Long memberId;
 
     @ManyToOne
-    @JoinColumn(name = "user_id", nullable = true)
+    @JoinColumn(name = "user_id", nullable = false)
     private User user;
 
     @ManyToOne(fetch = FetchType.LAZY)
@@ -56,11 +56,12 @@ public class Member {
         this.isMemberDeleted = true;
     }
 
-    public void restoreMember() {
-        this.isMemberDeleted = false;
-    }
-
     public void editSchedule(String availableTime) {
         this.availableTime = availableTime;
+    }
+
+    public void reJoin() {
+        this.isMemberDeleted = false;
+        this.lastAccessTime = LocalDateTime.now();
     }
 }

--- a/src/main/java/com/example/weup/entity/Member.java
+++ b/src/main/java/com/example/weup/entity/Member.java
@@ -64,4 +64,8 @@ public class Member {
         this.isMemberDeleted = false;
         this.lastAccessTime = LocalDateTime.now();
     }
+
+    public void assignDeletedUser(User user) {
+        this.user = user;
+    }
 }

--- a/src/main/java/com/example/weup/repository/MemberRepository.java
+++ b/src/main/java/com/example/weup/repository/MemberRepository.java
@@ -8,13 +8,11 @@ import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
-import java.util.Collection;
 import java.util.List;
 import java.util.Optional;
 
 @Repository
 public interface MemberRepository extends JpaRepository<Member, Long> {
-    boolean existsByUserAndProject(User user, Project project);
 
     List<Member> findByProject_ProjectIdAndIsMemberDeletedFalse(Long projectId);
 
@@ -33,8 +31,6 @@ public interface MemberRepository extends JpaRepository<Member, Long> {
     List<Member> findAllByUser_UserId(Long userId);
 
     List<Member> findByUser_UserIdAndIsLeaderTrue(Long userId);
-
-    Optional<Member> findFirstByProjectAndUser_UserIdNotOrderByMemberIdAsc(Project project, Long userId);
 
     List<Member> findByUser(User user);
 

--- a/src/main/java/com/example/weup/repository/MemberRepository.java
+++ b/src/main/java/com/example/weup/repository/MemberRepository.java
@@ -8,6 +8,7 @@ import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
+import java.util.Collection;
 import java.util.List;
 import java.util.Optional;
 
@@ -38,4 +39,6 @@ public interface MemberRepository extends JpaRepository<Member, Long> {
     List<Member> findByUser(User user);
 
     List<Member> findByProject(Project project);
+
+    List<Member> findAllByProjectAndUser_UserIdNotOrderByMemberIdAsc(Project project, Long userId);
 }

--- a/src/main/java/com/example/weup/service/UserService.java
+++ b/src/main/java/com/example/weup/service/UserService.java
@@ -179,7 +179,7 @@ public class UserService {
             List<Member> members = memberRepository.findByUser(user);
             for (Member member : members) {
                 User deletedUser = userRepository.findById(3L)
-                        .orElseThrow(() -> new GeneralException(ErrorInfo.USER_NOT_FOUND));;
+                        .orElseThrow(() -> new GeneralException(ErrorInfo.USER_NOT_FOUND));
                 member.setUser(deletedUser); //todo
             }
             memberRepository.saveAll(members);

--- a/src/main/java/com/example/weup/service/UserService.java
+++ b/src/main/java/com/example/weup/service/UserService.java
@@ -180,7 +180,7 @@ public class UserService {
             for (Member member : members) {
                 User deletedUser = userRepository.findById(3L)
                         .orElseThrow(() -> new GeneralException(ErrorInfo.USER_NOT_FOUND));
-                member.setUser(deletedUser); //todo
+                member.assignDeletedUser(deletedUser);
             }
             memberRepository.saveAll(members);
             userRepository.delete(user);


### PR DESCRIPTION
## User_Id
1 - 관리자
2 - AI
3 - 삭제된 유저들

## 유저 삭제 시
30일 지나기 전까지는 iswithdraw만 true
30일이 지나면 완전 삭제(fk를 3으로)

## 유저 탈퇴 후 30일 전에 복구 시
멤버 isdeleted는 그대로 true, 프로젝트들은 재초대받아야 들어갈 수 있음

## 탈퇴 회원 재초대 시
이메일이 같고 isdeleted가 true면 false로 바꿔서 복원
재초대받았을 시 안에 있는 데이터들은 다 그대로

복구를 하고 프로젝트에 초대되지 않아도 해당 프로젝트 내부 데이터는 다 그대로 (그냥 프로젝트 나간 사람이랑 같음)
