### PR TITLE
FIX: setDisplayType in chat, withdrawUser in user

### DIFF
--- a/src/main/java/com/example/weup/service/UserService.java
+++ b/src/main/java/com/example/weup/service/UserService.java
@@ -42,6 +42,7 @@ public class UserService {
     private final MailService mailService;
 
     private final S3Service s3Service;
+    private final ProjectService projectService;
 
     @Value("${user.default-profile-image}")
     private String defaultProfileImage;
@@ -166,7 +167,7 @@ public class UserService {
                 nextLeader.promoteToLeader();
                 leader.demoteFromLeader();
             } else {
-                // todo. 프로젝트 삭제 로직 추가
+                projectService.deleteProject(userId, project.getProjectId());
             }
         }
 


### PR DESCRIPTION
## chat
setDisplayType 호출 시 member가 null일 경우 member.getMemberId()에서 NullPointerException 발생
-> member가 null이 아닐 경우만 비교, null일 경우에는 senderType 가져와 비교

## user
유저 삭제 시 소속 프로젝트 탈퇴 로직에서, 남은 인원이 없으면 프로젝트 삭제되는 로직 추가