### PR TITLE
[FIX] Schedule Response Type

### DIFF
--- a/src/main/java/com/example/weup/controller/ProjectController.java
+++ b/src/main/java/com/example/weup/controller/ProjectController.java
@@ -42,7 +42,8 @@ public class ProjectController {
         Project newProject = projectService.createProject(projectCreateRequestDTO);
         Member newMember = memberService.addProjectCreater(userId, newProject);
         ChatRoom newChatRoom = chatRoomService.createBasicChatRoom(newProject, projectCreateRequestDTO.getProjectName());
-        chatRoomService.addChatRoomMember(newProject, newChatRoom, newMember.getMemberId());
+
+        chatRoomService.addChatRoomMember(newChatRoom, newMember.getMemberId());
 
         log.info("요청자 : {}, create project -> success", userId);
         return ResponseEntity.ok(DataResponseDTO.of("프로젝트가 성공적으로 생성되었습니다."));

--- a/src/main/java/com/example/weup/controller/ScheduleController.java
+++ b/src/main/java/com/example/weup/controller/ScheduleController.java
@@ -1,6 +1,7 @@
 package com.example.weup.controller;
 
 import com.example.weup.HandlerMethodArgumentResolver.annotation.LoginUser;
+import com.example.weup.dto.request.EditScheduleRequestDTO;
 import com.example.weup.dto.response.DataResponseDTO;
 import com.example.weup.dto.response.GetScheduleResponseDTO;
 import com.example.weup.service.ScheduleService;
@@ -32,10 +33,10 @@ public class ScheduleController {
 
     @PutMapping("/edit/{projectId}")
     public ResponseEntity<DataResponseDTO<String>> editSchedule(@LoginUser Long userId, @PathVariable Long projectId,
-                                                                @RequestBody String availableTime) {
+                                                                @RequestBody EditScheduleRequestDTO scheduleRequestDTO) {
 
         log.info("요청자 : {}, edit schedule -> start", userId);
-        scheduleService.editSchedule(userId, projectId, availableTime);
+        scheduleService.editSchedule(userId, projectId, scheduleRequestDTO);
 
         log.info("요청자 : {}, edit schedule -> success", userId);
         return ResponseEntity.ok(DataResponseDTO.of("이용 가능 시간 수정이 완료되었습니다."));

--- a/src/main/java/com/example/weup/dto/request/EditScheduleRequestDTO.java
+++ b/src/main/java/com/example/weup/dto/request/EditScheduleRequestDTO.java
@@ -1,0 +1,9 @@
+package com.example.weup.dto.request;
+
+import lombok.Getter;
+
+@Getter
+public class EditScheduleRequestDTO {
+
+    private String availableTime;
+}

--- a/src/main/java/com/example/weup/dto/response/GetScheduleResponseDTO.java
+++ b/src/main/java/com/example/weup/dto/response/GetScheduleResponseDTO.java
@@ -11,9 +11,10 @@ import lombok.NoArgsConstructor;
 @Builder
 public class GetScheduleResponseDTO {
 
+    private Long memberId;
+
     private String name;
 
     private String availableTime;
 
-    private Boolean isMine;
 }

--- a/src/main/java/com/example/weup/entity/Member.java
+++ b/src/main/java/com/example/weup/entity/Member.java
@@ -33,7 +33,7 @@ public class Member {
 
     @Column(name = "available_time", length = 252)
     @Builder.Default
-    private String availableTime = "0";
+    private String availableTime = "0".repeat(252);
 
     @Column(name = "is_member_deleted", nullable = false)
     @Builder.Default

--- a/src/main/java/com/example/weup/service/ChatRoomService.java
+++ b/src/main/java/com/example/weup/service/ChatRoomService.java
@@ -75,13 +75,13 @@ public class ChatRoomService {
         chatRoomRepository.save(chatRoom);
         log.info("채팅방 생성 완료, Chat Room ID : {}", chatRoom.getChatRoomId());
 
-        addChatRoomMember(project, chatRoom, creator.getMemberId());
+        addChatRoomMember(chatRoom, creator.getMemberId());
 
         List<Long> chatRoomMemberIds = createChatRoomDto.getChatRoomMemberId();
         if (chatRoomMemberIds != null && !createChatRoomDto.getChatRoomMemberId().isEmpty()) {
             for (Long memberId : chatRoomMemberIds) {
                 log.info("초대할 대상 Member ID : {}", memberId);
-                addChatRoomMember(project, chatRoom, memberId);
+                addChatRoomMember(chatRoom, memberId);
             }
         }
     }
@@ -125,17 +125,16 @@ public class ChatRoomService {
 
         ChatRoom chatRoom = chatRoomRepository.findById(chatRoomId)
                 .orElseThrow(() -> new GeneralException(ErrorInfo.CHAT_ROOM_NOT_FOUND));
-        Project project = projectValidator.validateActiveProject(chatRoom.getProject().getProjectId());
 
         for (Long memberId : inviteChatRoomDTO.getInviteMemberIds()) {
-            addChatRoomMember(project, chatRoom, memberId);
+            addChatRoomMember(chatRoom, memberId);
         }
     }
 
     @Transactional
-    public void addChatRoomMember(Project project, ChatRoom chatRoom, Long memberId) throws JsonProcessingException {
+    public void addChatRoomMember(ChatRoom chatRoom, Long memberId) throws JsonProcessingException {
 
-        Member member = memberValidator.validateMember(project.getProjectId(), memberId);
+        Member member = memberValidator.validateMemberAndProject(memberId);
         memberValidator.isMemberAlreadyInChatRoom(chatRoom, member, false);
 
         ChatRoomMember chatRoomMember = ChatRoomMember.builder()

--- a/src/main/java/com/example/weup/service/ChatService.java
+++ b/src/main/java/com/example/weup/service/ChatService.java
@@ -63,7 +63,7 @@ public class ChatService{
 
         ChatRoom chatRoom = chatValidator.validateChatRoom(chatRoomId);
 
-        Member sendMember = memberValidator.validateMember(chatRoom.getProject().getProjectId(), messageRequestDTO.getSenderId());
+        Member sendMember = memberValidator.validateMemberAndProject(messageRequestDTO.getSenderId());
         memberValidator.isMemberAlreadyInChatRoom(chatRoom, sendMember, true);
 
         checkAndSendDateChangeMessage(chatRoomId, LocalDateTime.now());
@@ -90,11 +90,10 @@ public class ChatService{
 
         ChatRoom chatRoom = chatValidator.validateChatRoom(chatRoomId);
 
-        Member sendMember = memberValidator.validateMember(chatRoom.getProject().getProjectId(), sendImageMessageRequestDTO.getSenderId());
+        Member sendMember = memberValidator.validateMemberAndProject(sendImageMessageRequestDTO.getSenderId());
         memberValidator.isMemberAlreadyInChatRoom(chatRoom, sendMember, true);
 
         checkAndSendDateChangeMessage(chatRoomId, LocalDateTime.now());
-
         String storedFileName = s3Service.uploadSingleFile(sendImageMessageRequestDTO.getFile()).getStoredFileName();
 
         RedisMessageDTO imgMessage = RedisMessageDTO.builder()
@@ -258,7 +257,7 @@ public class ChatService{
             messageDTO.setSenderName(member.getUser().getName());
             messageDTO.setSenderProfileImage(s3Service.getPresignedUrl(member.getUser().getProfileImage()));
 
-            if (messageDTO.isImage()) {messageDTO.setMessage(s3Service.getPresignedUrl(messageDTO.getMessage()));}
+            if (messageDTO.isImage()) messageDTO.setMessage(s3Service.getPresignedUrl(messageDTO.getMessage()));
 
         } else if (messageDTO.getSenderType() == SenderType.AI) {
             messageDTO.setSenderId(null);
@@ -274,9 +273,7 @@ public class ChatService{
             messageDTO.setSenderName(SenderType.WITHDRAW.getName());
             messageDTO.setSenderProfileImage(s3Service.getPresignedUrl(SenderType.WITHDRAW.getProfileImage()));
 
-        } else {
-            throw new GeneralException(ErrorInfo.INTERNAL_ERROR);
-        }
+        } else throw new GeneralException(ErrorInfo.INTERNAL_ERROR);
 
         return messageDTO;
     }

--- a/src/main/java/com/example/weup/service/MemberService.java
+++ b/src/main/java/com/example/weup/service/MemberService.java
@@ -90,7 +90,7 @@ public class MemberService {
         if (existingMember != null) {
             if (existingMember.isMemberDeleted()) {
                 existingMember.reJoin();
-                chatRoomService.addChatRoomMember(project, chatRoomRepository.findByProjectAndBasicTrue(project), existingMember.getMemberId());
+                chatRoomService.addChatRoomMember(chatRoomRepository.findByProjectAndBasicTrue(project), existingMember.getMemberId());
                 return "초대가 완료되었습니다.";
             } else {
                 throw new GeneralException(ErrorInfo.ALREADY_IN_PROJECT);
@@ -107,7 +107,7 @@ public class MemberService {
                 .build();
         memberRepository.save(member);
 
-        chatRoomService.addChatRoomMember(project, chatRoomRepository.findByProjectAndBasicTrue(project), member.getMemberId());
+        chatRoomService.addChatRoomMember(chatRoomRepository.findByProjectAndBasicTrue(project), member.getMemberId());
 
         return "초대가 완료되었습니다.";
     }

--- a/src/main/java/com/example/weup/service/ScheduleService.java
+++ b/src/main/java/com/example/weup/service/ScheduleService.java
@@ -13,7 +13,6 @@ import org.springframework.transaction.annotation.Transactional;
 
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Objects;
 
 @Slf4j
 @Service

--- a/src/main/java/com/example/weup/service/ScheduleService.java
+++ b/src/main/java/com/example/weup/service/ScheduleService.java
@@ -1,5 +1,6 @@
 package com.example.weup.service;
 
+import com.example.weup.dto.request.EditScheduleRequestDTO;
 import com.example.weup.dto.response.GetScheduleResponseDTO;
 import com.example.weup.entity.Member;
 import com.example.weup.repository.MemberRepository;
@@ -35,9 +36,9 @@ public class ScheduleService {
 
         getMember.stream().map(
                 member -> GetScheduleResponseDTO.builder()
+                        .memberId(member.getMemberId())
                         .name(member.getUser().getName())
                         .availableTime(member.getAvailableTime())
-                        .isMine(Objects.equals(member.getUser().getUserId(), userId))
                         .build())
                 .forEach(responseDTOList::add);
 
@@ -46,11 +47,10 @@ public class ScheduleService {
     }
 
     @Transactional
-    public void editSchedule(Long userId, Long projectId, String availableTime) {
+    public void editSchedule(Long userId, Long projectId, EditScheduleRequestDTO scheduleRequestDTO) {
 
-        projectValidator.validateActiveProject(projectId);
         Member member = memberValidator.validateActiveMemberInProject(userId, projectId);
-        member.editSchedule(availableTime);
+        member.editSchedule(scheduleRequestDTO.getAvailableTime());
 
         memberRepository.save(member);
         log.info("edit schedule -> db save success : member id - {}", member.getMemberId());


### PR DESCRIPTION
### 🔥 Problem
기존에는 프론트가 사용자의 member id를 모르고 있었기 때문에 List로 넘겨주는 스케줄 데이터에서 어떤 값이 사용자의 데이터인지 구분하는 isMine 필드가 존재했었는데,

프론트가 member id를 가지고 있는 현재 상황에서는 isMine 필드 대신, 해당 데이터가 어떤 member의 데이터인지 식별하기 위한 member id (PK) 값을 넘겨줌.


### ✅ Task
- [ ] Member Entity -> availableTime field의 default value를 "0"에서 "0000....0000" (252byte)로 수정
- [ ] Get Schedule Response DTO -> isMine (Boolean) field를 memberId (Long) field로 변경