### PR TITLE
[FIX] WebSocket Session Service Logic

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -34,7 +34,7 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-websocket'
 
     implementation 'org.springframework.boot:spring-boot-starter'
-    implementation 'com.mysql:mysql-connector-j:9.3.0'
+    runtimeOnly 'com.mysql:mysql-connector-j:9.3.0'
 
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
     implementation 'org.springframework.boot:spring-boot-starter-validation'

--- a/src/main/java/com/example/weup/config/StompChannelInterceptor.java
+++ b/src/main/java/com/example/weup/config/StompChannelInterceptor.java
@@ -5,6 +5,7 @@ import com.example.weup.constant.ErrorInfo;
 import com.example.weup.entity.User;
 import com.example.weup.repository.UserRepository;
 import com.example.weup.security.JwtUtil;
+import com.example.weup.service.SessionService;
 import com.example.weup.validate.MemberValidator;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -28,6 +29,8 @@ import java.util.regex.Pattern;
 public class StompChannelInterceptor implements ChannelInterceptor {
 
     private final JwtUtil jwtUtil;
+
+    private final SessionService sessionService;
 
     private final UserRepository userRepository;
 
@@ -78,6 +81,7 @@ public class StompChannelInterceptor implements ChannelInterceptor {
                     log.info("Personal notification Subscribe -> Success : User - {}", userId);
                 }
                 else if (destination.startsWith("/topic/project")) {
+                    // todo. 왜 이렇게 해 뒀을까.....
                     Long targetEntityId = null;
                     Matcher chatRoomMatcher = CHATROOM_TOPIC_PATTERN.matcher(destination);
                     Matcher projectMatcher = PROJECT_TOPIC_PATTERN.matcher(destination);
@@ -91,11 +95,16 @@ public class StompChannelInterceptor implements ChannelInterceptor {
 
                     if (targetEntityId != null) {
                         memberValidator.validateActiveMemberInProject(userId, targetEntityId);
-                        // TODO. 지금은 projectId = chatRoomId 라서 이게 통하는데 나중에 확장하면 바꿔야 함.
                         log.info("Topic Subscribe -> Success : User - {}, Destination - {}", userId, destination);
                     }
                     else {
                         log.warn("Topic Subscribe -> Failure : User - {}, Destination - {}", userId, destination);
+                    }
+                }
+                else if (destination.startsWith("/topic/chatroom")) {
+                    Matcher chatRoomMatcher = CHATROOM_TOPIC_PATTERN.matcher(destination);
+                    if (chatRoomMatcher.matches()) {
+                        Long chatRoomId = Long.parseLong(chatRoomMatcher.group(1));
                     }
                 }
                 break;

--- a/src/main/java/com/example/weup/config/StompEventListener.java
+++ b/src/main/java/com/example/weup/config/StompEventListener.java
@@ -26,7 +26,7 @@ public class StompEventListener {
         Authentication authentication = (Authentication) accessor.getUser();
         log.info("New WebSocket Connect : sessionId - {}", sessionId);
 
-        if(authentication != null && authentication.isAuthenticated()){
+        if (authentication != null && authentication.isAuthenticated()){
             User user = (User) authentication.getPrincipal();
             String userId = String.valueOf(user.getUserId());
 
@@ -41,6 +41,15 @@ public class StompEventListener {
     public void handlerWebSocketDisconnect(SessionDisconnectEvent event) {
         StompHeaderAccessor accessor = StompHeaderAccessor.wrap(event.getMessage());
         String sessionId = accessor.getSessionId();
+
+        String userIdStr = sessionService.getUserIdBySession(sessionId);
+        if (userIdStr == null) {
+            log.warn("WebSocket Disconnect : No userId for sessionId - {}", sessionId);
+            sessionService.removeSession(sessionId);
+            return;
+        }
+
+
 
         log.info("WebSocket Disconnect : sessionId - {}", sessionId);
         sessionService.removeSession(sessionId);

--- a/src/main/java/com/example/weup/config/StompEventListener.java
+++ b/src/main/java/com/example/weup/config/StompEventListener.java
@@ -22,7 +22,6 @@ public class StompEventListener {
     public void handlerWebSocketConnect(SessionConnectedEvent event) {
         StompHeaderAccessor accessor = StompHeaderAccessor.wrap(event.getMessage());
         String sessionId = accessor.getSessionId();
-        System.out.println("sessionId:" + sessionId);
 
         Authentication authentication = (Authentication) accessor.getUser();
         log.info("New WebSocket Connect : sessionId - {}", sessionId);
@@ -31,7 +30,7 @@ public class StompEventListener {
             User user = (User) authentication.getPrincipal();
             String userId = String.valueOf(user.getUserId());
 
-            sessionService.save(sessionId, userId);
+            sessionService.saveSession(sessionId, userId);
             log.info("WebSocket Connect -> Success : user Id - {}, session Id - {}", userId, sessionId);
         } else {
             log.warn("WebSocket Connect -> Fail : session Id - {}", sessionId);
@@ -44,6 +43,6 @@ public class StompEventListener {
         String sessionId = accessor.getSessionId();
 
         log.info("WebSocket Disconnect : sessionId - {}", sessionId);
-        sessionService.remove(sessionId);
+        sessionService.removeSession(sessionId);
     }
 }

--- a/src/main/java/com/example/weup/config/WebSocketConfig.java
+++ b/src/main/java/com/example/weup/config/WebSocketConfig.java
@@ -1,5 +1,6 @@
 package com.example.weup.config;
 
+import com.example.weup.handler.StompChannelInterceptor;
 import lombok.RequiredArgsConstructor;
 import org.jetbrains.annotations.NotNull;
 import org.springframework.context.annotation.Configuration;

--- a/src/main/java/com/example/weup/controller/AiChatController.java
+++ b/src/main/java/com/example/weup/controller/AiChatController.java
@@ -33,6 +33,7 @@ public class AiChatController {
     public ResponseEntity<DataResponseDTO<String>> aiAssignRole(@RequestBody AiRoleAssignRequestDTO aiRoleAssignDto) {
 
         log.info("요청자 : Flask Server, AI Assign Role -> start");
+        log.debug("project id : {}, user name : {}, role name : {}", aiRoleAssignDto.getProjectId(), aiRoleAssignDto.getUserName(), aiRoleAssignDto.getRoleName());
         aiChatService.aiAssignRole(aiRoleAssignDto);
 
         log.info("요청자 : Flask Server, AI Assign Role -> success");
@@ -43,6 +44,7 @@ public class AiChatController {
     public ResponseEntity<DataResponseDTO<String>> aiTodoCreate(@RequestBody AiTodoCreateRequestDTO aiTodoCreateDto) {
 
         log.info("요청자 : Flask Server, AI Todo Create -> start");
+        log.debug("project id : {}, todo name : {}, start date : {}", aiTodoCreateDto.getProjectId(), aiTodoCreateDto.getTodoName(), aiTodoCreateDto.getStartDate());
         aiChatService.aiTodoCreate(aiTodoCreateDto);
 
         log.info("요청자 : Flask Server, AI Todo Create -> success");

--- a/src/main/java/com/example/weup/controller/ChatController.java
+++ b/src/main/java/com/example/weup/controller/ChatController.java
@@ -15,6 +15,7 @@ import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.*;
 
 import java.io.IOException;
+import java.security.Principal;
 
 @Slf4j
 @Controller
@@ -54,6 +55,17 @@ public class ChatController {
 
         log.info("요청자 : {}, get chatting messages -> success", userId);
         return ResponseEntity.ok(DataResponseDTO.of(data, "채팅 내역 조회가 완료되었습니다."));
+    }
+
+    @MessageMapping("/topic/chat/active/{chatRoomId}")
+    public void eventChatRoomEntry(@DestinationVariable("chatRoomId") Long chatRoomId, Principal principal) throws JsonProcessingException {
+
+        log.debug("event chat room entry, principal get name : {}", principal.getName());
+        Long userId = Long.valueOf(principal.getName());
+        log.debug("event chat room entry, user id : {}", userId);
+
+        chatService.processChatRoomEntry(chatRoomId, userId);
+        chatService.enterChatRoomEvent(chatRoomId, userId);
     }
 
 }

--- a/src/main/java/com/example/weup/controller/ChatController.java
+++ b/src/main/java/com/example/weup/controller/ChatController.java
@@ -15,7 +15,6 @@ import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.*;
 
 import java.io.IOException;
-import java.security.Principal;
 
 @Slf4j
 @Controller
@@ -55,17 +54,6 @@ public class ChatController {
 
         log.info("요청자 : {}, get chatting messages -> success", userId);
         return ResponseEntity.ok(DataResponseDTO.of(data, "채팅 내역 조회가 완료되었습니다."));
-    }
-
-    @MessageMapping("/topic/chat/active/{chatRoomId}")
-    public void eventChatRoomEntry(@DestinationVariable("chatRoomId") Long chatRoomId, Principal principal) throws JsonProcessingException {
-
-        log.debug("event chat room entry, principal get name : {}", principal.getName());
-        Long userId = Long.valueOf(principal.getName());
-        log.debug("event chat room entry, user id : {}", userId);
-
-        chatService.processChatRoomEntry(chatRoomId, userId);
-        chatService.enterChatRoomEvent(chatRoomId, userId);
     }
 
 }

--- a/src/main/java/com/example/weup/dto/request/AiTodoCreateRequestDTO.java
+++ b/src/main/java/com/example/weup/dto/request/AiTodoCreateRequestDTO.java
@@ -14,6 +14,4 @@ public class AiTodoCreateRequestDTO {
     private String todoName;
 
     private LocalDate startDate;
-
-    //private Long memberId;
 }

--- a/src/main/java/com/example/weup/dto/response/EnterChatRoomResponseDTO.java
+++ b/src/main/java/com/example/weup/dto/response/EnterChatRoomResponseDTO.java
@@ -1,9 +1,11 @@
 package com.example.weup.dto.response;
 
 import lombok.Builder;
+import lombok.Getter;
 
 import java.time.Instant;
 
+@Getter
 @Builder
 public class EnterChatRoomResponseDTO {
 

--- a/src/main/java/com/example/weup/dto/response/EnterChatRoomResponseDTO.java
+++ b/src/main/java/com/example/weup/dto/response/EnterChatRoomResponseDTO.java
@@ -1,0 +1,13 @@
+package com.example.weup.dto.response;
+
+import lombok.Builder;
+
+import java.time.Instant;
+
+@Builder
+public class EnterChatRoomResponseDTO {
+
+    private Long memberId;
+
+    private Instant lastReadTime;
+}

--- a/src/main/java/com/example/weup/dto/response/GetChatRoomListDTO.java
+++ b/src/main/java/com/example/weup/dto/response/GetChatRoomListDTO.java
@@ -5,6 +5,7 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
+import java.time.LocalDateTime;
 import java.util.List;
 
 @NoArgsConstructor
@@ -24,4 +25,8 @@ public class GetChatRoomListDTO {
     private Boolean isBasic;
 
     private long unreadMessageCount;
+
+    private String lastMessage;
+
+    private LocalDateTime lastMessageTime;
 }

--- a/src/main/java/com/example/weup/dto/response/ReceiveMessageResponseDTO.java
+++ b/src/main/java/com/example/weup/dto/response/ReceiveMessageResponseDTO.java
@@ -15,6 +15,8 @@ import java.time.LocalDateTime;
 @Setter
 public class ReceiveMessageResponseDTO {
 
+    private String uuid;
+
     private Long senderId;
 
     private String senderName;
@@ -36,8 +38,11 @@ public class ReceiveMessageResponseDTO {
 
     private String originalMessage;
 
+    private int unreadCount;
+
     public static ReceiveMessageResponseDTO fromRedisMessageDTO(RedisMessageDTO chatMessage) {
         return ReceiveMessageResponseDTO.builder()
+                .uuid(chatMessage.getUuid())
                 .senderId(chatMessage.getSenderType()==SenderType.MEMBER ? chatMessage.getMemberId() : null)
                 .message(chatMessage.getMessage())
                 .sentAt(chatMessage.getSentAt())

--- a/src/main/java/com/example/weup/dto/response/RedisMessageDTO.java
+++ b/src/main/java/com/example/weup/dto/response/RedisMessageDTO.java
@@ -17,6 +17,8 @@ public class RedisMessageDTO {
 
     private Long chatRoomId;
 
+    private String uuid;
+
     private Long memberId;
 
     private String message;

--- a/src/main/java/com/example/weup/dto/response/RedisMessageDTO.java
+++ b/src/main/java/com/example/weup/dto/response/RedisMessageDTO.java
@@ -2,14 +2,12 @@ package com.example.weup.dto.response;
 
 import com.example.weup.constant.DisplayType;
 import com.example.weup.constant.SenderType;
-import lombok.AllArgsConstructor;
-import lombok.Builder;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
+import lombok.*;
 
 import java.time.LocalDateTime;
 
 @Getter
+@Setter
 @NoArgsConstructor
 @AllArgsConstructor
 @Builder

--- a/src/main/java/com/example/weup/handler/ExceptionHandlers.java
+++ b/src/main/java/com/example/weup/handler/ExceptionHandlers.java
@@ -1,4 +1,4 @@
-package com.example.weup.config;
+package com.example.weup.handler;
 
 import com.example.weup.GeneralException;
 import com.example.weup.constant.ErrorInfo;
@@ -11,7 +11,6 @@ import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
-import org.springframework.web.servlet.mvc.method.annotation.ResponseEntityExceptionHandler;
 
 @RestControllerAdvice(annotations = {RestController.class})
 public class ExceptionHandlers {

--- a/src/main/java/com/example/weup/handler/StompChannelInterceptor.java
+++ b/src/main/java/com/example/weup/handler/StompChannelInterceptor.java
@@ -99,14 +99,14 @@ public class StompChannelInterceptor implements ChannelInterceptor {
                 }
                 // 채팅방 알림 진입
                 else if (destination.startsWith("/topic/chat")) {
-                    Long chatRoomId;
+                    long chatRoomId;
 
                     if (destination.split("/")[3].equals("active")) {
-                        chatRoomId = Long.valueOf(destination.split("/")[4]);
+                        chatRoomId = Long.parseLong(destination.split("/")[4]);
                         log.info("Topic(Chatroom Active) Subscribe -> Success : User - {}, Destination - {}, chat room id - {}", userId, destination, chatRoomId);
                     }
                     else if (destination.split("/")[3].equals("connect")) {
-                        chatRoomId = Long.valueOf(destination.split("/")[4]);
+                        chatRoomId = Long.parseLong(destination.split("/")[4]);
                         log.debug("split 확인 해보자 : {}", Arrays.toString(destination.split("/")));
                         log.info("Topic(Chatroom Connect) Subscribe -> Success : User - {}, Destination - {}, chat room id - {}", userId, destination, chatRoomId);
                         sessionService.addConnectMemberToChatRoom(chatRoomId, userId);

--- a/src/main/java/com/example/weup/handler/StompEventListener.java
+++ b/src/main/java/com/example/weup/handler/StompEventListener.java
@@ -14,8 +14,6 @@ import org.springframework.web.socket.messaging.SessionConnectedEvent;
 import org.springframework.web.socket.messaging.SessionDisconnectEvent;
 import org.springframework.web.socket.messaging.SessionSubscribeEvent;
 
-import java.util.Objects;
-
 @Component
 @Slf4j
 @RequiredArgsConstructor

--- a/src/main/java/com/example/weup/repository/ChatMessageRepository.java
+++ b/src/main/java/com/example/weup/repository/ChatMessageRepository.java
@@ -24,7 +24,8 @@ public interface ChatMessageRepository extends JpaRepository<ChatMessage, Long> 
 
     List<ChatMessage> findByMember(Member member);
 
-    List<Long> findMessageIdByChatRoom_ChatRoomIdAndSentAtAfter(Long chatRoomId, LocalDateTime sentAt);
+    @Query("SELECT m FROM ChatMessage m WHERE m.chatRoom.chatRoomId = :chatRoomId AND m.sentAt > :sentAt")
+    List<ChatMessage> findChatMessageByChatRoom_ChatRoomIdAndSentAtAfter(@Param("chatRoomId") Long chatRoomId, @Param("sentAt") LocalDateTime sentAt);
 
     long countByChatRoom_ChatRoomIdAndSentAtAfter(Long chatRoomId, LocalDateTime lastDateTime);
 }

--- a/src/main/java/com/example/weup/repository/ChatRoomMemberRepository.java
+++ b/src/main/java/com/example/weup/repository/ChatRoomMemberRepository.java
@@ -16,4 +16,6 @@ public interface ChatRoomMemberRepository extends JpaRepository<ChatRoomMember, 
     ChatRoomMember findByChatRoomAndMember(ChatRoom chatRoom, Member member);
 
     List<ChatRoomMember> findByMember(Member member);
+
+    int countByChatRoom_ChatRoomId(Long chatRoomId);
 }

--- a/src/main/java/com/example/weup/service/AiChatService.java
+++ b/src/main/java/com/example/weup/service/AiChatService.java
@@ -81,7 +81,6 @@ public class AiChatService {
             HttpEntity<Map<String, Object>> requestEntity = new HttpEntity<>(jsonBody, headers);
 
             log.info("send message to ai -> POST Request To AI Flask Server start : url - {}", aiServerUrl);
-            log.debug("send message to ai -> request data check : {}", requestEntity.toString());
             ResponseEntity<String> response = restTemplate.postForEntity(aiServerUrl, requestEntity, String.class);
 
             JsonNode root = objectMapper.readTree(response.getBody());

--- a/src/main/java/com/example/weup/service/AiChatService.java
+++ b/src/main/java/com/example/weup/service/AiChatService.java
@@ -4,8 +4,6 @@ import com.example.weup.GeneralException;
 import com.example.weup.constant.ErrorInfo;
 import com.example.weup.dto.request.*;
 import com.example.weup.constant.SenderType;
-import com.example.weup.dto.response.ReceiveMessageResponseDTO;
-import com.example.weup.dto.response.RedisMessageDTO;
 import com.example.weup.entity.*;
 import com.example.weup.repository.*;
 import com.example.weup.validate.ProjectValidator;
@@ -19,7 +17,6 @@ import org.springframework.http.HttpEntity;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
-import org.springframework.messaging.simp.SimpMessagingTemplate;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.client.RestClientException;
@@ -108,14 +105,16 @@ public class AiChatService {
     public void aiAssignRole(AiRoleAssignRequestDTO aiRoleAssignDto) {
 
         Project project = projectValidator.validateActiveProject(aiRoleAssignDto.getProjectId());
+        log.debug("project validator -> end");
 
         Member member = memberRepository.findByUser_NameAndProject_ProjectId(aiRoleAssignDto.getUserName(), project.getProjectId());
+        log.debug("member validator -> end");
 
         Role role = roleRepository.findByProjectAndRoleName(project, aiRoleAssignDto.getRoleName())
                         .orElseThrow(() -> new GeneralException(ErrorInfo.ROLE_NOT_FOUND));
+        log.debug("role validator -> end");
 
         memberRoleRepository.deleteByMember(member);
-
         MemberRole memberRole = MemberRole.builder()
                 .member(member)
                 .role(role)

--- a/src/main/java/com/example/weup/service/SessionService.java
+++ b/src/main/java/com/example/weup/service/SessionService.java
@@ -1,23 +1,14 @@
 package com.example.weup.service;
 
-import com.example.weup.dto.response.EnterChatRoomResponseDTO;
-import com.example.weup.dto.response.RedisMessageDTO;
 import com.example.weup.entity.Member;
-import com.example.weup.repository.ChatMessageRepository;
 import com.example.weup.validate.ChatValidator;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.redis.core.StringRedisTemplate;
-import org.springframework.messaging.simp.SimpMessagingTemplate;
 import org.springframework.stereotype.Service;
 
 import java.time.Instant;
-import java.time.LocalDateTime;
-import java.time.ZoneId;
-import java.util.HashSet;
-import java.util.List;
 import java.util.Set;
-import java.util.stream.Collectors;
 
 @Slf4j
 @Service
@@ -27,8 +18,6 @@ public class SessionService {
     private final StringRedisTemplate redisTemplate;
 
     private final ChatValidator chatValidator;
-
-    private final ChatMessageRepository chatMessageRepository;
 
     private static final String SESSION_TO_USER_KEY = "ws:session:";
     private static final String CHATROOM_ACTIVE_MEMBERS_KEY = "chatroom:%s:active:members";
@@ -103,6 +92,7 @@ public class SessionService {
 
     // lastReadAt 저장
     public void saveLastReadAt(Long chatRoomId, Long userId, Instant lastReadAt) {
+        log.debug("\n\n session service - save last read at IN");
         redisTemplate.opsForValue().set(String.format(LAST_READ_AT_KEY, chatRoomId, userId), String.valueOf(lastReadAt.toEpochMilli()));
     }
 
@@ -112,23 +102,4 @@ public class SessionService {
         if (lastReadAtStr == null) return null;
         return Instant.ofEpochMilli(Long.parseLong(lastReadAtStr));
     }
-
-//    private Set<String> getMessagesSentAfter(Long chatRoomId, Instant lastReadAt) {
-//        Set<String> messageIds = new HashSet<>();
-//        String messageKey = "chat:room:" + chatRoomId;
-//        long minScore = lastReadAt.toEpochMilli();
-//
-//        Set<String> redisMessageIds = redisTemplate.opsForZSet().rangeByScore(messageKey, minScore, Double.POSITIVE_INFINITY);
-//        if (redisMessageIds != null) {
-//            messageIds.addAll(redisMessageIds);
-//        }
-//
-//        LocalDateTime lastReadLocalDateTime = LocalDateTime.ofInstant(lastReadAt, ZoneId.systemDefault());
-//        //List<Long> mysqlMessageIds = chatMessageRepository.findMessageIdByChatRoom_ChatRoomIdAndSentAtAfter(chatRoomId, lastReadLocalDateTime);
-//        if (mysqlMessageIds != null) {
-//            messageIds.addAll(mysqlMessageIds.stream().map(String::valueOf).collect(Collectors.toSet()));
-//        }
-//
-//        return messageIds;
-//    }
 }

--- a/src/main/java/com/example/weup/service/SessionService.java
+++ b/src/main/java/com/example/weup/service/SessionService.java
@@ -1,50 +1,114 @@
 package com.example.weup.service;
 
+import com.example.weup.entity.Member;
+import com.example.weup.validate.ChatValidator;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.redis.core.StringRedisTemplate;
 import org.springframework.stereotype.Service;
 
-import java.util.Collection;
-import java.util.Collections;
+import java.time.Instant;
 import java.util.Set;
-import java.util.concurrent.ConcurrentHashMap;
-import java.util.concurrent.ConcurrentMap;
 
 @Service
+@RequiredArgsConstructor
 public class SessionService {
 
-    private final ConcurrentMap<String, String> sessionIdToUserMap = new ConcurrentHashMap<>();
-    private final ConcurrentMap<String, Set<String>> userToSessionIdMap = new ConcurrentHashMap<>();
+    private final StringRedisTemplate redisTemplate;
 
-    public void save(String sessionId, String userId) {
-        sessionIdToUserMap.put(sessionId, userId);
-        userToSessionIdMap.computeIfAbsent(userId, k -> ConcurrentHashMap.newKeySet()).add(sessionId);
+    private final ChatValidator chatValidator;
+
+    private static final String SESSION_TO_USER_KEY = "ws:session";
+    private static final String USER_TO_SESSIONS_KEY = "ws:user:%s:sessions";
+    private static final String CHATROOM_ACTIVE_MEMBERS_KEY = "chatroom:%s:active:members";
+    private static final String CHATROOM_CONNECT_MEMBERS_KEY = "chatroom:%s:connect:members";
+    private static final String LAST_READ_AT_KEY = "chatroom:%s:lastReatAt:%s";
+
+    // session connect
+    public void saveSession(String sessionId, String userId) {
+        redisTemplate.opsForValue().set(SESSION_TO_USER_KEY + sessionId, userId);
+        redisTemplate.opsForSet().add(String.format(USER_TO_SESSIONS_KEY, userId), sessionId);
     }
 
-    public void remove(String sessionId) {
-        String userId = sessionIdToUserMap.remove(sessionId);
+    // session disconnect
+    public void removeSession(String sessionId) {
+        String userId = redisTemplate.opsForValue().get(SESSION_TO_USER_KEY + sessionId);
         if (userId != null) {
-            Set<String> sessions = userToSessionIdMap.get(userId);
-            if (sessions != null) {
-                sessions.remove(sessionId);
-                if (sessions.isEmpty()) {
-                    userToSessionIdMap.remove(userId);
-                }
-            }
+            redisTemplate.delete(SESSION_TO_USER_KEY + sessionId);
+            redisTemplate.opsForSet().remove(String.format(USER_TO_SESSIONS_KEY, userId), sessionId);
         }
     }
 
-    public String getUserId(String sessionId) {
-        return sessionIdToUserMap.get(sessionId);
+    // session id -> user id 조회
+    public String getUserIdBySession(String sessionId) {
+        return redisTemplate.opsForValue().get(SESSION_TO_USER_KEY + sessionId);
     }
 
-    public Set<String> getSessionsByUserId(String userId) {
-        return userToSessionIdMap.getOrDefault(userId, Collections.emptySet());
+    // user id -> session ids 조회
+    public Set<String> getSessionsByUserId(Long userId) {
+        return redisTemplate.opsForSet().members(String.format(USER_TO_SESSIONS_KEY, userId));
     }
 
-    public Collection<String> getOnlineUserIds() {
-        return userToSessionIdMap.keySet();
+    // user 온라인 상태인지 확인
+    public boolean isUserOnline(Long userId) {
+        Long size = redisTemplate.opsForSet().size(String.format(USER_TO_SESSIONS_KEY, userId));
+        return size != null && size > 0;
     }
 
-    public boolean isUserOnline(String userId) {
-        return userToSessionIdMap.containsKey(userId) && !userToSessionIdMap.get(userId).isEmpty();
+    // 채팅방 active member 추가
+    public void addActiveMemberToChatRoom(Long chatRoomId, Long userId) {
+        Member member = chatValidator.validateMemberInChatRoomSession(chatRoomId, userId);
+        redisTemplate.opsForSet().add(String.format(CHATROOM_ACTIVE_MEMBERS_KEY, chatRoomId), String.valueOf(member.getMemberId()));
+    }
+
+    // 채팅방 active member 제거
+    public void removeActiveMemberFromChatRoom(Long chatRoomId, Long userId) {
+        Member member = chatValidator.validateMemberInChatRoomSession(chatRoomId, userId);
+        redisTemplate.opsForSet().remove(String.format(CHATROOM_ACTIVE_MEMBERS_KEY, chatRoomId), String.valueOf(member.getMemberId()));
+    }
+
+    // 채팅방 active member 목록 조회
+    public Set<String> getActiveChatRoomMembers(Long chatRoomId) {
+        return redisTemplate.opsForSet().members(String.format(CHATROOM_ACTIVE_MEMBERS_KEY, chatRoomId));
+    }
+
+    // 채팅방 active member 수 조회
+    public long getActiveMembersCountInChatRoom(Long chatRoomId) {
+        Long size = redisTemplate.opsForSet().size(String.format(CHATROOM_ACTIVE_MEMBERS_KEY, chatRoomId));
+        return size != null ? size : 0;
+    }
+
+    // 채팅방 connect member 추가
+    public void addConnectMemberToChatRoom(Long chatRoomId, Long userId) {
+        Member member = chatValidator.validateMemberInChatRoomSession(chatRoomId, userId);
+        redisTemplate.opsForSet().add(String.format(CHATROOM_CONNECT_MEMBERS_KEY, chatRoomId), String.valueOf(member.getMemberId()));
+    }
+
+    // 채팅방 connect member 제거
+    public void removeConnectMemberFromChatRoom(Long chatRoomId, Long userId) {
+        Member member = chatValidator.validateMemberInChatRoomSession(chatRoomId, userId);
+        redisTemplate.opsForSet().remove(String.format(CHATROOM_CONNECT_MEMBERS_KEY, chatRoomId), String.valueOf(member.getMemberId()));
+    }
+
+    // 채팅방 connect member 목록 조회
+    public Set<String> getConnectChatRoomMembers(Long chatRoomId) {
+        return redisTemplate.opsForSet().members(String.format(CHATROOM_CONNECT_MEMBERS_KEY, chatRoomId));
+    }
+
+    // 채팅방 connect member 수 조회
+    public long getConnectMembersCountInChatRoom(Long chatRoomId) {
+        Long size = redisTemplate.opsForSet().size(String.format(CHATROOM_CONNECT_MEMBERS_KEY, chatRoomId));
+        return size != null ? size : 0;
+    }
+
+    // lastReadAt 저장
+    public void saveLastReadAt(Long chatRoomId, Long userId, Instant lastReadAt) {
+        redisTemplate.opsForValue().set(String.format(LAST_READ_AT_KEY, chatRoomId, userId), String.valueOf(lastReadAt.toEpochMilli()));
+    }
+
+    // lastReadAt 불러오기
+    public Instant getLastReadAt(Long chatRoomId, Long userId) {
+        String lastReadAtStr = redisTemplate.opsForValue().get(String.format(LAST_READ_AT_KEY, chatRoomId, userId));
+        if (lastReadAtStr == null) return null;
+        return Instant.ofEpochMilli(Long.parseLong(lastReadAtStr));
     }
 }

--- a/src/main/java/com/example/weup/service/SessionService.java
+++ b/src/main/java/com/example/weup/service/SessionService.java
@@ -21,7 +21,7 @@ public class SessionService {
     private static final String USER_TO_SESSIONS_KEY = "ws:user:%s:sessions";
     private static final String CHATROOM_ACTIVE_MEMBERS_KEY = "chatroom:%s:active:members";
     private static final String CHATROOM_CONNECT_MEMBERS_KEY = "chatroom:%s:connect:members";
-    private static final String LAST_READ_AT_KEY = "chatroom:%s:lastReatAt:%s";
+    private static final String LAST_READ_AT_KEY = "chatroom:%s:lastReadAt:%s";
 
     // session connect
     public void saveSession(String sessionId, String userId) {

--- a/src/main/java/com/example/weup/validate/ChatValidator.java
+++ b/src/main/java/com/example/weup/validate/ChatValidator.java
@@ -3,7 +3,9 @@ package com.example.weup.validate;
 import com.example.weup.GeneralException;
 import com.example.weup.constant.ErrorInfo;
 import com.example.weup.entity.ChatRoom;
+import com.example.weup.entity.Member;
 import com.example.weup.repository.ChatRoomRepository;
+import com.example.weup.repository.MemberRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
 
@@ -13,9 +15,18 @@ public class ChatValidator {
 
     private final ChatRoomRepository chatRoomRepository;
 
+    private final MemberValidator memberValidator;
+
     public ChatRoom validateChatRoom(Long chatRoomId) {
 
         return chatRoomRepository.findById(chatRoomId)
                 .orElseThrow(() -> new GeneralException(ErrorInfo.CHAT_ROOM_NOT_FOUND));
     }
+
+    public Member validateMemberInChatRoomSession(Long chatRoomId, Long userId) {
+        ChatRoom chatRoom = validateChatRoom(chatRoomId);
+
+        return memberValidator.validateActiveMemberInProject(userId, chatRoom.getProject().getProjectId());
+    }
+
 }

--- a/src/main/java/com/example/weup/validate/ChatValidator.java
+++ b/src/main/java/com/example/weup/validate/ChatValidator.java
@@ -5,7 +5,6 @@ import com.example.weup.constant.ErrorInfo;
 import com.example.weup.entity.ChatRoom;
 import com.example.weup.entity.Member;
 import com.example.weup.repository.ChatRoomRepository;
-import com.example.weup.repository.MemberRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
 

--- a/src/main/java/com/example/weup/validate/ChatValidator.java
+++ b/src/main/java/com/example/weup/validate/ChatValidator.java
@@ -6,8 +6,10 @@ import com.example.weup.entity.ChatRoom;
 import com.example.weup.entity.Member;
 import com.example.weup.repository.ChatRoomRepository;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Component;
 
+@Slf4j
 @Component
 @RequiredArgsConstructor
 public class ChatValidator {
@@ -17,12 +19,16 @@ public class ChatValidator {
     private final MemberValidator memberValidator;
 
     public ChatRoom validateChatRoom(Long chatRoomId) {
+        log.debug("chat validator - validate chat room IN");
+        log.debug("chat validator 1 - chat room id : {}", chatRoomId);
         return chatRoomRepository.findById(chatRoomId)
                 .orElseThrow(() -> new GeneralException(ErrorInfo.CHAT_ROOM_NOT_FOUND));
     }
 
     public Member validateMemberInChatRoomSession(Long chatRoomId, Long userId) {
+        log.debug("chat validator - validate member in chat room session IN");
         ChatRoom chatRoom = validateChatRoom(chatRoomId);
+        log.debug("chat validator 2 - chat room id : {}", chatRoomId);
         return memberValidator.validateActiveMemberInProject(userId, chatRoom.getProject().getProjectId());
     }
 

--- a/src/main/java/com/example/weup/validate/ChatValidator.java
+++ b/src/main/java/com/example/weup/validate/ChatValidator.java
@@ -18,14 +18,12 @@ public class ChatValidator {
     private final MemberValidator memberValidator;
 
     public ChatRoom validateChatRoom(Long chatRoomId) {
-
         return chatRoomRepository.findById(chatRoomId)
                 .orElseThrow(() -> new GeneralException(ErrorInfo.CHAT_ROOM_NOT_FOUND));
     }
 
     public Member validateMemberInChatRoomSession(Long chatRoomId, Long userId) {
         ChatRoom chatRoom = validateChatRoom(chatRoomId);
-
         return memberValidator.validateActiveMemberInProject(userId, chatRoom.getProject().getProjectId());
     }
 

--- a/src/main/java/com/example/weup/validate/ChatValidator.java
+++ b/src/main/java/com/example/weup/validate/ChatValidator.java
@@ -20,7 +20,6 @@ public class ChatValidator {
 
     public ChatRoom validateChatRoom(Long chatRoomId) {
         log.debug("chat validator - validate chat room IN");
-        log.debug("chat validator 1 - chat room id : {}", chatRoomId);
         return chatRoomRepository.findById(chatRoomId)
                 .orElseThrow(() -> new GeneralException(ErrorInfo.CHAT_ROOM_NOT_FOUND));
     }
@@ -28,7 +27,6 @@ public class ChatValidator {
     public Member validateMemberInChatRoomSession(Long chatRoomId, Long userId) {
         log.debug("chat validator - validate member in chat room session IN");
         ChatRoom chatRoom = validateChatRoom(chatRoomId);
-        log.debug("chat validator 2 - chat room id : {}", chatRoomId);
         return memberValidator.validateActiveMemberInProject(userId, chatRoom.getProject().getProjectId());
     }
 

--- a/src/main/java/com/example/weup/validate/MemberValidator.java
+++ b/src/main/java/com/example/weup/validate/MemberValidator.java
@@ -55,6 +55,7 @@ public class MemberValidator {
     }
 
     public Member validateMemberAndProject(Long memberId) {
+        log.debug("member validate, validation member and project - memberId: {}", memberId);
         Member member = memberRepository.findById(memberId)
                 .orElseThrow(() -> new GeneralException(ErrorInfo.MEMBER_NOT_FOUND));
 
@@ -68,6 +69,7 @@ public class MemberValidator {
     }
 
     public void isMemberAlreadyInChatRoom(ChatRoom chatRoom, Member member, boolean targetResult) {
+        log.debug("member validate, is member already in chat room? - memberId: {}", member.getMemberId());
         if (targetResult) {
             if (!chatRoomMemberRepository.existsByChatRoomAndMember(chatRoom, member)) {
                 throw new GeneralException(ErrorInfo.MEMBER_NOT_FOUND);

--- a/src/main/java/com/example/weup/validate/MemberValidator.java
+++ b/src/main/java/com/example/weup/validate/MemberValidator.java
@@ -24,6 +24,7 @@ public class MemberValidator {
     private final ProjectValidator projectValidator;
 
     public Member validateActiveMemberInProject(Long userId, Long projectId) {
+        log.debug("member validator - validate active member in project : {}", projectId);
         Member member = memberRepository.findByUser_UserIdAndProject_ProjectId(userId, projectId)
                 .orElseThrow(() -> new GeneralException(ErrorInfo.NOT_IN_PROJECT));
 
@@ -31,6 +32,7 @@ public class MemberValidator {
             throw new GeneralException(ErrorInfo.DELETED_MEMBER);
         }
 
+        log.debug("member validator -> end");
         return member;
     }
 

--- a/src/main/resources/application-dev.properties
+++ b/src/main/resources/application-dev.properties
@@ -6,7 +6,7 @@ spring.datasource.url=jdbc:mysql://${DB_HOST}:${DB_PORT}/${DB_NAME}
 spring.datasource.username=${DB_USERNAME}
 spring.datasource.password=${DB_PASSWORD}
 
-spring.jpa.hibernate.ddl-auto=create
+spring.jpa.hibernate.ddl-auto=update
 spring.jpa.show-sql=false
 spring.jpa.properties.hibernate.format_sql=true
 spring.jpa.properties.hibernate.highlight_sql=false


### PR DESCRIPTION
### 🔥 Problem
Issue #110 작업을 하다 보니 WebSocket Session 관리를 HashMap에서 Redis로 전환해야 하고, 추가적으로 관리해야 하는 것들이 늘어남.
현재 관리하고 있는 정보는 다음과 같음.
- Session에 있는 User가 누구인지 저장
- User마다 어떤 Session에 있는지 저장 (여러 개의 세션을 가질 수 있음)
- 현재 채팅방에서 활동중인 멤버 저장
- 채팅 탭에는 들어왔지만, 채팅을 실시간으로 읽을 수 없는 (활동중이지 않은) 멤버 저장
- 멤버가 마지막으로 채팅을 읽은 시간 저장

나중에 추가될 수 있음.

실시간 기능 개발을 위해 해당 부분만 먼저 Dev에 Merge함.
