### PR TITLE
[FIX] getBoardDetail - add to return memberId

### DIFF
--- a/src/main/java/com/example/weup/dto/response/BoardDetailResponseDTO.java
+++ b/src/main/java/com/example/weup/dto/response/BoardDetailResponseDTO.java
@@ -11,6 +11,7 @@ import java.util.List;
 public class BoardDetailResponseDTO {
     private String name;
     private String profileImage;
+    private Long memberId;
     private String title;
     private String contents;
     private LocalDateTime boardCreatedTime;

--- a/src/main/java/com/example/weup/service/BoardService.java
+++ b/src/main/java/com/example/weup/service/BoardService.java
@@ -99,6 +99,7 @@ public class BoardService {
         return BoardDetailResponseDTO.builder()
                 .name(getWriterName(board))
                 .profileImage(getWriterProfileImage(board))
+                .memberId(board.getMember().getMemberId())
                 .title(board.getTitle())
                 .contents(board.getContents())
                 .boardCreatedTime(board.getBoardCreateTime())


### PR DESCRIPTION
타인의 게시글 상세보기 시 수정 버튼을 표기하지 않기 위해
memberId를 같이 반환하도록 수정